### PR TITLE
Add validation task for application name, routes, services and stack

### DIFF
--- a/src/CloudFoundry.Build.Tasks.Test/CloudFoundry.Build.Tasks.Test.csproj
+++ b/src/CloudFoundry.Build.Tasks.Test/CloudFoundry.Build.Tasks.Test.csproj
@@ -136,6 +136,7 @@
     <Compile Include="LoadYamlTaskTest.cs" />
     <Compile Include="SaveYamlTaskTest.cs" />
     <Compile Include="UpdateAppTaskTest.cs" />
+    <Compile Include="ValidateTaskTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/src/CloudFoundry.Build.Tasks.Test/TestUtils.cs
+++ b/src/CloudFoundry.Build.Tasks.Test/TestUtils.cs
@@ -292,7 +292,7 @@ namespace CloudFoundry.Build.Tasks.Test
 
         internal static List<ListAllOrganizationsResponse> CustomListAllOrganizationsResponse(PagedResponseCollection<ListAllOrganizationsResponse> arg1)
         {
-            return new List<ListAllOrganizationsResponse>() { new ListAllOrganizationsResponse(){ EntityMetadata=new Metadata()}};
+            return new List<ListAllOrganizationsResponse>() { new ListAllOrganizationsResponse(){ EntityMetadata=new Metadata() }};
 
         }
 
@@ -304,6 +304,11 @@ namespace CloudFoundry.Build.Tasks.Test
         internal static List<ListAllSpacesForOrganizationResponse> CustomListAllSpacesForOrganizationResponse(PagedResponseCollection<ListAllSpacesForOrganizationResponse> arg1)
         {
             return new List<ListAllSpacesForOrganizationResponse>() {new ListAllSpacesForOrganizationResponse(){ EntityMetadata=new Metadata(), Name="TestSpace"}};
+        }
+
+        internal static EntityGuid CustomMetadataGuidGet(Metadata arg1)
+        {
+            return EntityGuid.FromGuid(Guid.NewGuid());
         }
     }
 }

--- a/src/CloudFoundry.Build.Tasks.Test/ValidateTaskTest.cs
+++ b/src/CloudFoundry.Build.Tasks.Test/ValidateTaskTest.cs
@@ -1,0 +1,129 @@
+﻿using CloudFoundry.Build.Tasks.Test.Properties;
+using CloudFoundry.CloudController.V2.Client.Data;
+using Microsoft.QualityTools.Testing.Fakes;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CloudFoundry.Build.Tasks.Test
+{
+     [TestClass]
+   
+    public class ValidateTaskTest
+    {
+         private IDisposable context;
+         [TestInitialize]
+         public void Init_Validate()
+         {
+             context = ShimsContext.Create();
+              CloudFoundry.CloudController.V2.Client.Fakes.ShimCloudFoundryClient.AllInstances.LoginCloudCredentials = TestUtils.CustomLogin;
+
+                 CloudFoundry.CloudController.V2.Client.Base.Fakes.ShimAbstractStacksEndpoint.AllInstances.ListAllStacks = TestUtils.CustomListAllStacks;
+
+                 CloudFoundry.CloudController.V2.Client.Fakes.ShimPagedResponseCollection<ListAllStacksResponse>.AllInstances.ResourcesGet = TestUtils.CustomGetStacks;
+
+                 CloudFoundry.CloudController.V2.Client.Base.Fakes.ShimAbstractServicesEndpoint.AllInstances.ListAllServicesRequestOptions = TestUtils.CustomListAllServices;
+
+                 CloudFoundry.CloudController.V2.Client.Fakes.ShimPagedResponseCollection<ListAllServicesResponse>.AllInstances.ResourcesGet = TestUtils.CustomListAllServicesResponse;
+
+                 CloudFoundry.CloudController.V2.Client.Base.Fakes.ShimAbstractServicesEndpoint.AllInstances.ListAllServicePlansForServiceNullableOfGuid = TestUtils.CustomListServicePlans;
+
+                 CloudFoundry.CloudController.V2.Client.Fakes.ShimPagedResponseCollection<ListAllServicePlansForServiceResponse>.AllInstances.ResourcesGet = TestUtils.CustomListServicePlansResponse;
+
+                 CloudFoundry.CloudController.V2.Client.Base.Fakes.ShimAbstractServiceInstancesEndpoint.AllInstances.ListAllServiceInstances = TestUtils.CustomListAllServiceInstancesPlain;
+
+                 CloudFoundry.CloudController.V2.Client.Fakes.ShimPagedResponseCollection<ListAllServiceInstancesResponse>.AllInstances.ResourcesGet = TestUtils.CustomListAllServiceInstancesPlainResponse;
+
+                 CloudController.V2.Client.Base.Fakes.ShimAbstractDomainsDeprecatedEndpoint.AllInstances.ListAllDomainsDeprecated = TestUtils.CustomListAllDomains;
+
+                 CloudFoundry.CloudController.V2.Client.Fakes.ShimPagedResponseCollection<ListAllDomainsDeprecatedResponse>.AllInstances.ResourcesGet = TestUtils.CustomGetDomains;
+
+                 CloudFoundry.CloudController.V2.Client.Fakes.ShimPagedResponseCollection<ListAllOrganizationsResponse>.AllInstances.ResourcesGet = TestUtils.CustomListAllOrganizationsResponse;
+
+                 CloudFoundry.CloudController.V2.Client.Base.Fakes.ShimAbstractOrganizationsEndpoint.AllInstances.ListAllOrganizationsRequestOptions = TestUtils.CustomListAllOrganizations;
+
+                 CloudFoundry.CloudController.V2.Client.Fakes.ShimPagedResponseCollection<ListAllSpacesForOrganizationResponse>.AllInstances.ResourcesGet = TestUtils.CustomListAllSpacesForOrganizationResponse;
+
+                 CloudFoundry.CloudController.V2.Client.Base.Fakes.ShimAbstractOrganizationsEndpoint.AllInstances.ListAllSpacesForOrganizationNullableOfGuidRequestOptions = TestUtils.CustomListAllSpacesForOrganization;
+
+                 CloudFoundry.CloudController.V2.Client.Fakes.ShimMetadata.AllInstances.GuidGet = TestUtils.CustomMetadataGuidGet;
+
+         }
+
+         [TestCleanup]
+         public void Cleanup_Validate()
+         {
+             context.Dispose();
+         }
+
+         [TestMethod]
+         public void Validate_Test()
+         {
+             Validate task = GetValidateTask();
+
+             Assert.IsTrue(task.Execute());
+         }
+
+         [TestMethod]
+         public void ValidateBadName_Test()
+         {
+             Validate task = GetValidateTask();
+
+             task.CFAppName = "t@#!asda1";
+         
+             Assert.IsFalse(task.Execute());
+         }
+
+         [TestMethod]
+         public void ValidateBadService_Test()
+         {
+             Validate task = GetValidateTask();
+
+             task.CFServices = @"service1,bad,bad";
+
+             Assert.IsFalse(task.Execute());
+         }
+
+
+         [TestMethod]
+         public void ValidateBadStack_Test()
+         {
+             Validate task = GetValidateTask();
+
+             task.CFStack="badStack";
+
+             Assert.IsFalse(task.Execute());
+         }
+
+
+         [TestMethod]
+         public void ValidateBadRoutes_Test()
+         {
+             Validate task = GetValidateTask();
+
+             task.CFRoutes=new string[1]{ "bad.bad.com"};
+
+             Assert.IsFalse(task.Execute());
+         }
+
+         private static Validate GetValidateTask()
+         {
+             Validate task = new Validate();
+             task.BuildEngine = new FakeBuildEngine();
+
+             task.CFUser = Settings.Default.User;
+             task.CFPassword = Settings.Default.Password;
+             task.CFServerUri = Settings.Default.ServerUri;
+             task.CFSpace = "TestSpace";
+             task.CFOrganization = "TestOrg";
+             task.CFStack = "testStack";
+             task.CFAppName = "testApp";
+             task.CFRoutes = new string[2] { "test.domain.com;test3.domain.com", "test2.domain.com" };
+             task.CFServices = @"service1,mysql,myPlan;service2,mssql2012,myPlan;";
+             return task;
+         }
+    }
+}

--- a/src/CloudFoundry.Build.Tasks/CloudFoundry.Build.Tasks.csproj
+++ b/src/CloudFoundry.Build.Tasks/CloudFoundry.Build.Tasks.csproj
@@ -124,6 +124,7 @@
     <Compile Include="src\UnbindService.cs" />
     <Compile Include="src\UpdateApp.cs" />
     <Compile Include="src\Utils.cs" />
+    <Compile Include="src\Validate.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="build\cf-msbuild-tasks.targets" />

--- a/src/CloudFoundry.Build.Tasks/build/cf-msbuild-tasks.targets
+++ b/src/CloudFoundry.Build.Tasks/build/cf-msbuild-tasks.targets
@@ -15,6 +15,7 @@
   <UsingTask AssemblyFile="Cloudfoundry.Build.Tasks.dll" TaskName="SaveYaml" />
   <UsingTask AssemblyFile="Cloudfoundry.Build.Tasks.dll" TaskName="DeleteApp" />
   <UsingTask AssemblyFile="Cloudfoundry.Build.Tasks.dll" TaskName="RestartApp" />
+  <UsingTask AssemblyFile="Cloudfoundry.Build.Tasks.dll" TaskName="Validate" />
 
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v12.0\Web\Microsoft.Web.Publishing.targets" Condition="false" />
 
@@ -64,7 +65,10 @@
       <Output TaskParameter="CFRefreshToken" PropertyName="CFRefreshToken"/>
     </LoginTask>
 
-    <CreateApp CFAppName="$(CFAppName)" CFStack="$(CFStack)" CFOrganization="$(CFOrganization)" CFSpace="$(CFSpace)" CFServerUri="$(CFServerUri)" CFEnvironmentJson="@(CFEnvironmentJson)" CFRefreshToken="$(CFRefreshToken)" CFAppMemory="$(CFAppMemory)" CFAppInstances="$(CFAppInstances)" CFSkipSslValidation="$(CFSkipSslValidation)">
+	<Validate CFAppName="$(CFAppName)" CFStack="$(CFStack)" CFOrganization="$(CFOrganization)" CFSpace="$(CFSpace)" CFServerUri="$(CFServerUri)" CFRefreshToken="$(CFRefreshToken)" CFRoutes="@(CFRoutes)" CFServices="$(CFServices)" CFSkipSslValidation="$(CFSkipSslValidation)">
+	</Validate>
+	
+    <CreateApp CFAppName="$(CFAppName)" CFStack="$(CFStack)" CFOrganization="$(CFOrganization)" CFSpace="$(CFSpace)" CFServerUri="$(CFServerUri)" CFEnvironmentJson="$(CFEnvironmentJson)" CFRefreshToken="$(CFRefreshToken)" CFAppMemory="$(CFAppMemory)" CFAppInstances="$(CFAppInstances)" CFSkipSslValidation="$(CFSkipSslValidation)">
       <Output TaskParameter="CFAppGuid" PropertyName="CFAppGuid"/>
     </CreateApp>
 

--- a/src/CloudFoundry.Build.Tasks/src/Validate.cs
+++ b/src/CloudFoundry.Build.Tasks/src/Validate.cs
@@ -1,0 +1,180 @@
+﻿using CloudFoundry.CloudController.V2.Client;
+using CloudFoundry.CloudController.V2.Client.Data;
+using Microsoft.Build.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace CloudFoundry.Build.Tasks
+{
+    public class Validate : BaseTask
+    {
+        [Required]
+        public string CFAppName { get; set; }
+
+        [Required]
+        public string CFOrganization { get; set; }
+
+        [Required]
+        public string CFSpace { get; set; }
+
+        [Required]
+        public string CFStack { get; set; }
+
+        [Required]
+        public String[] CFRoutes { get; set; }
+
+        public string CFServices { get; set; }
+
+        private Regex reg = new Regex(@"^[a-zA-Z0-9_]*$");
+
+        public override bool Execute()
+        {
+            logger = new Microsoft.Build.Utilities.TaskLoggingHelper(this);
+            CloudFoundryClient client = InitClient();
+            
+            if (reg.IsMatch(CFAppName) == false)
+            {
+                logger.LogError("Invalid application name {0}", CFAppName);
+                return false;
+            }
+
+            PagedResponseCollection<ListAllStacksResponse> stackList = client.Stacks.ListAllStacks().Result;
+
+            var stackInfo = stackList.Where(o => o.Name == CFStack).FirstOrDefault();
+
+            if (stackInfo == null)
+            {
+                logger.LogError("Stack {0} not found", CFStack);
+                return false;
+            }
+            
+            Guid? spaceGuid = Utils.GetSpaceGuid(client, logger, CFOrganization, CFSpace);
+
+            if (spaceGuid.HasValue == false)
+            {
+                logger.LogError("Invalid space and organization");
+                return false;
+            }
+
+            PagedResponseCollection<ListAllDomainsDeprecatedResponse> domainInfoList = client.DomainsDeprecated.ListAllDomainsDeprecated().Result;
+
+            foreach (String Route in CFRoutes)
+            {
+                foreach (var url in Route.Split(';'))
+                {
+                    logger.LogMessage("Validating route {0}", url);
+                    string domain = string.Empty;
+                    string host = string.Empty;
+                    Utils.ExtractDomainAndHost(url, out domain, out host);
+
+                    if (domain.Length == 0 || host.Length == 0)
+                    {
+                        logger.LogError("Error extracting domain and host information from route {0}", url);
+                        continue;
+                    }
+
+                    ListAllDomainsDeprecatedResponse domainInfo = domainInfoList.Where(o => o.Name == domain).FirstOrDefault();
+
+                    if (domainInfo == null)
+                    {
+                        logger.LogError("Domain {0} not found", domain);
+                        return false;
+                    }
+                }
+            }
+
+            if (string.IsNullOrWhiteSpace(CFServices) == false)
+            {
+                if (ValidateServices(client, CFServices) == false)
+                {
+                    logger.LogError("Error validating services");
+                    return false;
+                }
+            }
+
+
+            return true;
+        }
+
+
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]
+        private bool ValidateServices(CloudFoundryClient client, string CFServices)
+        {
+            List<ProvisionedService> servicesList = new List<ProvisionedService>();
+            try
+            {
+                string[] provServs = CFServices.Split(';');
+
+                foreach (string service in provServs)
+                {
+                    if (string.IsNullOrWhiteSpace(service) == false)
+                    {
+                        string[] serviceInfo = service.Split(',');
+
+                        if (serviceInfo.Length != 3)
+                        {
+                            logger.LogError("Invalid service information in {0}", service);
+                            continue;
+                        }
+
+                        ProvisionedService serviceDetails = new ProvisionedService();
+
+                        serviceDetails.Name = serviceInfo[0].Trim();
+                        serviceDetails.Type = serviceInfo[1].Trim();
+                        serviceDetails.Plan = serviceInfo[2].Trim();
+
+                        servicesList.Add(serviceDetails);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.LogErrorFromException(ex);
+                logger.LogWarning("Error trying to obtain service information, trying to deserialize as xml");
+                servicesList = Utils.Deserialize<List<ProvisionedService>>(CFServices);
+            }
+
+            foreach (ProvisionedService service in servicesList)
+            {
+                logger.LogMessage("Validating {0} service {1}", service.Type, service.Name);
+
+                if (reg.IsMatch(service.Name) == false)
+                {
+                    logger.LogError("Invalid service name {0}", service.Name);
+                    return false;
+                }
+
+                PagedResponseCollection<ListAllServicesResponse> allServicesList = client.Services.ListAllServices(new RequestOptions() { Query = "label:" + service.Type }).Result;
+
+                if (allServicesList.Count() < 1)
+                {
+                    logger.LogError("Invalid service type {0}", service.Type);
+                    return false;
+                }
+
+                foreach (var serviceInfo in allServicesList)
+                {
+                    var planList = client.Services.ListAllServicePlansForService(new Guid(serviceInfo.EntityMetadata.Guid)).Result;
+
+                    var plan = planList.Where(o => o.Name == service.Plan).FirstOrDefault();
+
+                    if (plan != null)
+                    {
+                        break;
+                    }
+                    else
+                    {
+                        logger.LogError("Invalid plan {2} for service {0} - {1}", service.Name, service.Type, service.Plan);
+                        return false;
+                    }
+                }
+            }
+
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
Added a validation task to provide a fail-fast response in case there is a problem with the parameters used to publish an application to the cloud.
 
This task checks if the application name contains invalid characters, if the stack is available on the cloud and if the domains requested for route creation exist.

As an optional parameter, the validation task can check if the parameters used for service creation are viable. It checks the service names for invalid characters, it checks if the requested service types exists and if the plan exists for that specific service type.