### PR TITLE
Add resolve CFAppPath in targets file, declare PUBLISH_WEBSITE as a property not as an array

### DIFF
--- a/src/CloudFoundry.Build.Tasks/build/cf-msbuild-tasks.targets
+++ b/src/CloudFoundry.Build.Tasks/build/cf-msbuild-tasks.targets
@@ -20,8 +20,10 @@
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v12.0\Web\Microsoft.Web.Publishing.targets" Condition="false" />
 
   <PropertyGroup>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">$(MSBuildProjectDirectory)\..\</SolutionDir>
+    <CFAppPath Condition="'$(CFAppPath)'=='' Or $(CFAppPath) == '*Undefined*'">$(SolutionDir)</CFAppPath>
     <NewGuid>$([System.Guid]::NewGuid())</NewGuid>
-    <PublishTempAppPath>$(TEMP)\$(NewGuid)</PublishTempAppPath>
+    <PublishTempAppPath>$(TEMP)\$(NewGuid)</PublishTempAppPath>    
   </PropertyGroup>
 
   <!-- Publish application to TEMP location -->
@@ -54,10 +56,13 @@
 
     <CallTarget Condition="'$(CFLocalBuild)'=='false'" Targets="CopySolutionFiles"></CallTarget>
 
+    <PropertyGroup>
+      <PUBLISH_WEBSITE Condition="'$(CFLocalBuild)'=='false' AND '$(PUBLISH_WEBSITE)' == ''">$(ProjectName)</PUBLISH_WEBSITE>
+    </PropertyGroup>
+    
     <ItemGroup>
       <CFRoutes Include="$(CFRoutes)"></CFRoutes>
       <CFRefreshToken Include="$(CFRefreshToken)"></CFRefreshToken>
-      <PUBLISH_WEBSITE Condition="'$(CFLocalBuild)'=='false' AND '$(PUBLISH_WEBSITE)' == ''" Include="$(ProjectName)"></PUBLISH_WEBSITE>
       <CFEnvironmentJson Condition="'$(CFLocalBuild)'=='false'" Include="{&quot;PUBLISH_WEBSITE&quot;: &quot;$(PUBLISH_WEBSITE)&quot;, &quot;MSBUILD_CONFIGURATION&quot;: &quot;$(CFMSBuildConfiguration)&quot;, &quot;MSBUILD_PLATFORM&quot;: &quot;$(CFMSBuildPlatform)&quot;}"></CFEnvironmentJson>
     </ItemGroup>
 


### PR DESCRIPTION
CFAppPath is used in the context of local build = false. If CFAppPath is explicitly specified that value will be used. If is not specified and $(SolutionDir) exists, $(SolutionDir) will be used. If $(SolutionDir) doesn't exists a msbuild error is raised and publish stops.