### PR TITLE
Remove nlog. Log stacktrace as detailed verbosity message

### DIFF
--- a/src/CloudFoundry.Build.Tasks/packages.config
+++ b/src/CloudFoundry.Build.Tasks/packages.config
@@ -5,7 +5,6 @@
   <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net45" />
   <package id="Microsoft.Net.Http" version="2.2.28" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.5" targetFramework="net45" />
-  <package id="NLog" version="3.2.1" targetFramework="net45" />
   <package id="protobuf-net" version="2.0.0.668" targetFramework="net45" />
   <package id="Simple.CredentialManager" version="1.0.0" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.49.1" targetFramework="net45" developmentDependency="true" />

--- a/src/CloudFoundry.Build.Tasks/src/TaskLogger.cs
+++ b/src/CloudFoundry.Build.Tasks/src/TaskLogger.cs
@@ -9,21 +9,9 @@
     using System.Threading.Tasks;
     using Microsoft.Build.Framework;
     using Microsoft.Build.Utilities;
-    using NLog;
-    using NLog.Config;
-    using NLog.Targets;
-    using NLog.Targets.Wrappers;
 
     internal class TaskLogger
     {
-        private static readonly NLog.Logger Log = LogManager.GetLogger(System.AppDomain.CurrentDomain.FriendlyName);
-    
-        private static readonly object ConfigureLock = new object();
-        
-        private static bool configured = false;
-        
-        private static string logFile = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "cf-msbuild-tasks", "cf-msbuild-tasks.log");
-        
         private TaskLoggingHelper logger;
     
         public TaskLogger(ITask task)
@@ -45,8 +33,6 @@
             else
             {
                 this.logger.LogError(message, args);
-                Configure();
-                Log.Error(CultureInfo.InvariantCulture, message, args);
             }
         }
 
@@ -58,22 +44,16 @@
         internal void LogMessage(string message, params object[] args)
         {
             this.logger.LogMessage(message, args);
-            Configure();
-            Log.Info(CultureInfo.InvariantCulture, message, args);
         }
 
         internal void LogWarning(string message, params object[] args)
         {
             this.logger.LogWarning(message, args);
-            Configure();
-            Log.Warn(CultureInfo.InvariantCulture, message, args);
         }
 
         internal void LogErrorFromException(Exception ex)
         {
             this.logger.LogErrorFromException(ex);
-            Configure();
-            Log.ErrorException(ex.Message, ex);
         }
 
         private static void FormatExceptionMessage(Exception ex, List<string> message)
@@ -96,46 +76,6 @@
             }
         }
 
-        private static void Configure()
-        {
-            if (configured)
-            {
-                return;
-            }
-
-            lock (ConfigureLock)
-            {
-                if (configured)
-                {
-                    return;
-                }
-
-                string directory = Path.GetDirectoryName(logFile);
-                Directory.CreateDirectory(directory);
-
-                FileTarget target = new FileTarget();
-
-                target.FileName = logFile;
-                target.ArchiveNumbering = ArchiveNumberingMode.Rolling;
-                target.ArchiveEvery = FileArchivePeriod.None;
-                target.ArchiveAboveSize = 10485760;
-                target.MaxArchiveFiles = 1;
-                target.Layout = new NLog.Layouts.SimpleLayout("${longdate}|${level:uppercase=true}|${logger}|${message}${onexception:EXCEPTION OCCURRED:|${exception:format=tostring}}");
-
-                AsyncTargetWrapper wrapper = new AsyncTargetWrapper(target, 5000, AsyncTargetWrapperOverflowAction.Discard);
-
-                LogManager.Configuration = new NLog.Config.LoggingConfiguration();
-                LogManager.Configuration.AddTarget("file", wrapper);
-
-                LoggingRule fileRule = new LoggingRule("*", LogLevel.Trace, wrapper);
-                LogManager.Configuration.LoggingRules.Add(fileRule);
-
-                LogManager.ReconfigExistingLoggers();
-
-                configured = true;
-            }
-        }
-
         private void LogExceptionVerbose(string message, Exception exception)
         {
             if (exception.GetType() == typeof(AggregateException))
@@ -147,13 +87,7 @@
             }
             else
             {
-                Configure();                
-                Log.ErrorException(message, exception);
-
-                if (exception.InnerException != null)
-                {
-                    Log.ErrorException(message, exception.InnerException);
-                }
+                this.logger.LogMessage(MessageImportance.Low, string.Format(CultureInfo.InstalledUICulture, "{0}: {1}", message, exception.ToString()));
             }
         }
     }


### PR DESCRIPTION
Error stacktrace is shown by using detailed verbosity when running the msbuild task (verbosity:detailed)