### PR TITLE
Parse loggregator message timestamp as unix nano

### DIFF
--- a/src/CloudFoundry.Build.Tasks.IntegrationTests/TaskFlow_Test.cs
+++ b/src/CloudFoundry.Build.Tasks.IntegrationTests/TaskFlow_Test.cs
@@ -27,10 +27,10 @@ namespace CloudFoundry.Build.Tasks.IntegrationTests
             string man = File.ReadAllText(manifest);
 
             man = string.Format(CultureInfo.InvariantCulture, man, guid, host, Settings.Default.Domain, appPath, Settings.Default.LinuxStack);
-            man += "  buildpack: https://github.com/cloudfoundry/php-buildpack";
+            man += "  buildpack: https://github.com/ActiveState/php-buildpack";
             File.WriteAllText(phpManifest, man);
 
-            Assert.IsTrue(RunTasks(phpManifest, host));
+            Assert.IsTrue(RunTasks(phpManifest, host, appPath));
         }
 
         [TestMethod]
@@ -50,10 +50,10 @@ namespace CloudFoundry.Build.Tasks.IntegrationTests
 
             File.WriteAllText(aspManifest, man);
 
-            Assert.IsTrue(RunTasks(aspManifest, host));
+            Assert.IsTrue(RunTasks(aspManifest, host, appPath));
         }
 
-        private bool RunTasks(string manifest, string host)
+        private bool RunTasks(string manifest, string host, string appPath)
         {
             LoginTask login = new LoginTask();
             login.BuildEngine = new FakeBuildEngine();
@@ -84,6 +84,7 @@ namespace CloudFoundry.Build.Tasks.IntegrationTests
             pushTask.CFManifest = manifest;
             pushTask.CFOrganization = Settings.Default.Organization;
             pushTask.CFSpace = Settings.Default.Space;
+            pushTask.CFAppPath = appPath;
 
             pushTask.BuildEngine = new FakeBuildEngine();
 

--- a/src/CloudFoundry.Build.Tasks/src/RestartApp.cs
+++ b/src/CloudFoundry.Build.Tasks/src/RestartApp.cs
@@ -105,9 +105,8 @@
 
                 loggregator.MessageReceived += (sender, message) =>
                 {
-                    var timeInTicks = message.LogMessage.Timestamp * TimeSpan.TicksPerSecond;
-
-                    var logTimeStamp = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc).AddTicks(timeInTicks);
+                    long timeInMilliSeconds = message.LogMessage.Timestamp / 1000 / 1000;
+                    var logTimeStamp = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc).AddMilliseconds(timeInMilliSeconds);
 
                     Logger.LogMessage("[{0}] - {1}: {2}", message.LogMessage.SourceName, logTimeStamp.ToString(), message.LogMessage.Message);
                 };


### PR DESCRIPTION
Logging failed when pushing an app to cf + bosh-lite. This patch may fix the issue.

@carabasdaniel  @mihaibuzgau  can you please check this out?